### PR TITLE
Add Linux instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,48 @@
 # Setup
 
+## Fork and clone this repo
+
+Fork [`lewagon/bitbar`](https://github.com/lewagon/bitbar) to your own GitHub account and clone it on your computer:
+
+```bash
+export GITHUB_USERNAME=`gh api user | jq -r '.login'`
+cd ~/code/GITHUB_USERNAME
+gh repo clone bitbar
+```
+
+Then make the `ticket.10s.rb` file executable:
+
+```bash
+cd ~/code/GITHUB_USERNAME/bitbar
+chmod a+x ticket.10s.rb
+```
+
+## Set up your script bar client
+
+### macOS
+
 Install Bitbar:
 
 ```bash
 brew cask install bitbar
 ```
 
-Clone this repo on your laptop then set the plugin as executable:
+Then launch the Bitbar app and choose `~/code/GITHUB_USERNAME/bitbar` as **Plugin Folder**
+
+### linux
+
+The equivalent of Bitbar for Linux is [Argos](https://github.com/p-e-w/argos).To install it go to [the GNOME extension page](https://extensions.gnome.org/extension/1176/argos/) and turn on the installation toggle.
+
+`Argos` monitors the `~/.config/argos` folder to look for scripts to execute. Remove the default `argos.sh` script there and link the `ticket.10s.rb` file to this folder:
 
 ```bash
-mkdir -p ~/code/lewagon
-gh repo clone lewagon/bitbar
-cd bitbar
-chmod a+x ticket.10s.rb
+rm ~/.config/argos/argos.sh
+ln -s ~/code/GITHUB_USERNAME/bitbar/ticket.10s.rb ~/.config/argos/ticket.10s.rb
 ```
 
-Launch the Bitbar app and choose `~/code/lewagon/bitbar` as **Plugin Folder**
+### Configure your script
 
-## Configuration
-
-Open the `~/code/lewagon/bitbar/ticket.10s.rb` file and make sure to change line `12`:
+Open the `~/code/GITHUB_USERNAME/bitbar/ticket.10s.rb` file and make sure to change line `12`:
 
 ```ruby
 BATCH_SLUG = 501

--- a/ticket.10s.rb
+++ b/ticket.10s.rb
@@ -9,7 +9,7 @@
 # <bitbar.dependencies>Ruby</bitbar.dependencies>
 
 ## CONFIGURATION
-BATCH_SLUG = 501
+BATCH_SLUG = 552
 
 
 ## SCRIPT

--- a/ticket.10s.rb
+++ b/ticket.10s.rb
@@ -11,7 +11,6 @@
 ## CONFIGURATION
 BATCH_SLUG = 552
 
-
 ## SCRIPT
 require 'net/http'
 require 'json'
@@ -49,7 +48,6 @@ class Plugin
     @status["color"] == "grey" ? "gray" : @status["color"]
   end
 end
-
 
 plugin = Plugin.new(BATCH_SLUG)
 puts "#{[plugin.emoji, plugin.count].join(" ")}|color=#{plugin.color}"


### PR DESCRIPTION
This PR add instructions to set up [Argos](https://github.com/p-e-w/argos), the equivalent on Linux of Bitbar. 

I've just set it up on my machine and it's working like a charm!

I also updated https://www.notion.so/lewagon/Ticket-Alert-4224bf40fc3c4b32a5b522a35eb7d134